### PR TITLE
fix: 테넌트 미식별 시 404 반환 및 버전 업

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "sellmate/laravel-multi-tenant",
-    "version": "12.1.1",
+    "version": "12.2.0",
     "license": "MIT",
     "description": "Multi tenant package for Laravel Framework",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "sellmate/laravel-multi-tenant",
-    "version": "12.1.0",
+    "version": "12.1.1",
     "license": "MIT",
     "description": "Multi tenant package for Laravel Framework",
     "authors": [

--- a/src/Middleware/HandleTenantConnection.php
+++ b/src/Middleware/HandleTenantConnection.php
@@ -34,6 +34,8 @@ class HandleTenantConnection
             DB::setDefaultConnection($manager->tenantConnectionName);
 
             return $next($request);
+        } else {
+            return abort(404);
         }
     }
 }

--- a/src/Middleware/HandleTenantConnection.php
+++ b/src/Middleware/HandleTenantConnection.php
@@ -27,7 +27,7 @@ class HandleTenantConnection
             return abort(404);
         }
 
-        $tenant = Tenant::where($idColumn, $tenantId)->get()->first();
+        $tenant = Tenant::where($idColumn, $tenantId)->first();
         if ($tenant) {
             $manager = new DatabaseManager();
             $manager->setTenantConnection($tenant);


### PR DESCRIPTION
 `HandleTenantConnection` 미들웨어에서 테넌트를 식별하지 못했을 때 `abort(404)` 반환하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant lookup handling so missing tenants now consistently return a 404 error.
* **Chores**
  * Bumped the package version to 12.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->